### PR TITLE
Fix Supabase logout route to use server client

### DIFF
--- a/src/app/api/users/logout/route.ts
+++ b/src/app/api/users/logout/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/client';
+import { createClient } from '@/lib/supabase/server';
 
 export async function POST() {
     try {
-        const supabase = createClient();
+        const supabase = await createClient();
         const { error } = await supabase.auth.signOut();
 
         if (error) {


### PR DESCRIPTION
## Summary
- ensure the logout API route uses the server-side Supabase client so it can run in the Node runtime
- await the server client creation before signing the user out

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fabf9db82c832397676025d31a3c8c